### PR TITLE
Use web-sys and remove use_extern_macros

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 cfg-if = "0.1.5"
-wasm-bindgen = "0.2.23"
+wasm-bindgen = "0.2.29"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -25,6 +25,16 @@ console_error_panic_hook = { version = "0.1.5", optional = true }
 # compared to the default allocator's ~10K. It is slower than the default
 # allocator, however.
 wee_alloc = { version = "0.4.2", optional = true }
+
+[dependencies.web-sys]
+version = "0.3.6"
+features = [
+  'Document',
+  'Element',
+  'HtmlElement',
+  'Node',
+  'Window',
+]
 
 [features]
 default-features = ["console_error_panic_hook", "wee_alloc"]

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -1,9 +1,8 @@
-#![feature(use_extern_macros)]
-
 #[macro_use]
 extern crate cfg_if;
 
 extern crate wasm_bindgen;
+extern crate web_sys;
 use wasm_bindgen::prelude::*;
 
 cfg_if! {
@@ -25,37 +24,21 @@ cfg_if! {
     }
 }
 
-// Definitions of the functionality available in JS, which wasm-bindgen will
-// generate shims for today (and eventually these should be near-0 cost!)
-//
-// These definitions need to be hand-written today but the current vision is
-// that we'll use WebIDL to generate this `extern` block into a crate which you
-// can link and import. There's a tracking issue for this at
-// https://github.com/rustwasm/wasm-bindgen/issues/42
-//
-// In the meantime these are written out by hand and correspond to the names and
-// signatures documented on MDN, for example
-#[wasm_bindgen]
-extern "C" {
-    type HTMLDocument;
-    static document: HTMLDocument;
-    #[wasm_bindgen(method)]
-    fn createElement(this: &HTMLDocument, tagName: &str) -> Element;
-    #[wasm_bindgen(method, getter)]
-    fn body(this: &HTMLDocument) -> Element;
-
-    type Element;
-    #[wasm_bindgen(method, setter = innerHTML)]
-    fn set_inner_html(this: &Element, html: &str);
-    #[wasm_bindgen(method, js_name = appendChild)]
-    fn append_child(this: &Element, other: Element);
-}
-
 // Called by our JS entry point to run the example
 #[wasm_bindgen]
-pub fn run() {
-    let val = document.createElement("p");
+pub fn run() -> Result<(), JsValue> {
+    // Use `web_sys`'s global `window` function to get a handle on the global
+    // window object.
+    let window = web_sys::window().expect("no global `window` exists");
+    let document = window.document().expect("should have a document on window");
+    let body = document.body().expect("document should have a body");
+
+    // Manufacture the element we're gonna append
+    let val = document.create_element("p")?;
     val.set_inner_html("Hello from Rust, WebAssembly, and Parcel!");
-    document.body().append_child(val);
+
+    body.append_child(&val)?;
+
+    Ok(())
 }
 


### PR DESCRIPTION
`use_extern_macros` is stable since 1.30 and doesn't seem to be needed
anymore. Also replaces the hand-written document definitions with usage
of the `web-sys` crate, now that it exists.

The rewritten `run` method is taken from the wasm-bindgen guide:
https://rustwasm.github.io/wasm-bindgen/examples/dom.html